### PR TITLE
Only publish (develop) documentation upon merging a PR from main

### DIFF
--- a/.github/workflows/documentation-deploy-development.yml
+++ b/.github/workflows/documentation-deploy-development.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-    - main
   workflow_dispatch:
 
 jobs:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
   -
     family-names: Zech
     given-names: Alraune
-    orcid: "https://orcid.org/0000-0002-8783-6198"   
+    orcid: "https://orcid.org/0000-0002-8783-6198"
   -
     family-names: Richardson
     given-names: Robin


### PR DESCRIPTION
Removes the trigger on commits to any pull request for the develop documentation publishing workflow. The workflow can still be triggered with the button "run this workflow" in the actions menu. However for the rest it will only run upon a push event (which also happens upon a PR merge) to the main branch.

fixes #168 

@joYvBa to review this PR I think it is sufficient to check that commits to this PR don't trigger the documentation_deploy_development workflow. We should also check that the workflow is still triggered once this is merged into main, because that should still trigger the action. 

